### PR TITLE
Update 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,6 @@ What the script does:
 Yes, you can modify or create your own collection.json files, and then use them to download / update.
 The script will download any items, which are specified in collection.json file.
 
-#### Color coding
-When downloading, downloaded items can be of different colors:
-
-- ![#The default color: Item is downloading](https://via.placeholder.com/15/fff/000000?text=+) Default color: Item is downloading
-- ![#Yellow color: Item is skipped due to being up-to-date](https://via.placeholder.com/15/ffbc0a/000000?text=+) Yellow color: Item is skipped due to being up-to-date
-- ![#Red color: Item is skipped due to error](https://via.placeholder.com/15/d80032/000000?text=+) Red color: Item is skipped due to error
-
 ### Options
 `python3 wcd.py -h`:
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ What the script does:
 3. Uses https://steamworkshopdownloader.io/ to download each item in collection, and save them to output directory.
 
 #### How to update?
-`python3 wcd.py -cjson OUTPUTFOLDER/my-collection-name/collection.json`
+`python3 wcd.py -cjson OUTPUTFOLDER/my-collection-name/collection.json -c`
 
 What the script does:
 1. Retrieves information about items in collection.json file from steam api.
@@ -24,7 +24,7 @@ The script will download any items, which are specified in collection.json file.
 ### Options
 `python3 wcd.py -h`:
 ```
-usage: wcd.py [-h] (-curl COLLECTIONURL | -cjson COLLECTIONJSON) [-o OUTPUT] [-f]
+usage: wcd.py [-h] (-curl COLLECTIONURL | -cjson COLLECTIONJSON) [-o OUTPUT] [-f] [-c]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -34,5 +34,6 @@ optional arguments:
                         Generated collection.json file from this script.
   -o OUTPUT, --output OUTPUT
                         Output directory. A folder with collection name will be saved here.
-  -f, --force           Force to redownload everything xD.
+  -f, --force           Force redownload everything.
+  -c, --cleanUp         Clean up removed items.
 ```

--- a/api/SteamAPI.py
+++ b/api/SteamAPI.py
@@ -160,7 +160,7 @@ def GetWorkshopCollectionInfo(collectionId: str) -> tuple[str, int, list[Worksho
         if item["filetype"] == 0
     ]
 
-    UpdatedItemsInfo = GetItemsUpdatedInfo(
+    UpdatedItemsInfo = GetItemsInfo(
         [collectionId] + collectionItemsIdList
     )
     collectionName = UpdatedItemsInfo[0].name
@@ -173,7 +173,11 @@ def GetWorkshopCollectionInfo(collectionId: str) -> tuple[str, int, list[Worksho
     )
 
 
-def GetItemsUpdatedInfo(fileIdList: list[int]) -> list[WorkshopItem]:
+def GetLocalCollectionInfo(collectionItems: list[WorkshopItem]) -> list[WorkshopItem]:
+    return GetItemsInfo([item.id for item in collectionItems])
+
+
+def GetItemsInfo(fileIdList: list[int]) -> list[WorkshopItem]:
     try:
         items = ISteamRemoteStorage.GetPublishedFileDetails(
             fileIdList

--- a/api/SteamDownloaderAPI.py
+++ b/api/SteamDownloaderAPI.py
@@ -23,19 +23,46 @@ def StopDownload():
         stopDownload = True
 
 
-def DownloadCollection(collection: WorkshopCollection, directory: str, forceRedownload: bool = False) -> None:
+def UpdateCollection(collection: WorkshopCollection, directory: str) -> None:
     '''Downloads all mods in collection.\n
     WARNING: collections maybe very big, so this command may generate a lot of internet traffic and take a while.'''
 
     global isDownloading
     global stopDownload
 
-    hasValidId = SteamAPI.Validator.ValidSteamItemId(collection.id) or \
-        collection.id == "DummyIdForLocalCollection"
+    newItemIdsList = [item.id for item in collection.newItems]
+    newItemIdsSet = set(newItemIdsList)
+    localItemIdsList = [item.id for item in collection.localItems]
+    localItemIdsSet = set(localItemIdsList)
+
+    willBeAddedIds: list[int] = list(
+        newItemIdsSet - localItemIdsSet
+    )
+    willBeDeletedIds: list[int] = set(
+        localItemIdsSet - newItemIdsSet
+    )
+    willBeUpdatedIds: list[int] = list(
+        item.id for item
+        in collection.localItems
+        if item.lastUpdated != collection.newItems[newItemIdsList.index(item.id)].lastUpdated
+    )
+    willBeIgnoredIds: list[int] = list(
+        (newItemIdsSet - set(willBeUpdatedIds)) - set(willBeAddedIds)
+    )
+
+    if (len(willBeUpdatedIds) == 0 and
+                len(willBeDeletedIds) == 0 and
+                len(willBeAddedIds) == 0
+            ):
+        logger.LogError(
+            f"{logger.StartIndent()}Collection has no items to download.\n"
+            f"{logger.Indent(1)}Called with collection: {collection}"
+        )
+        return
 
     hasValidAppId = SteamAPI.Validator.ValidSteamItemId(collection.appid)
 
-    if (not hasValidId or not hasValidAppId):
+    if (not hasValidAppId):
         logger.LogError(
             f"{logger.StartIndent()}Can't download collection without knowing its id or its app id.\n"
             f"{logger.Indent(1)}Call SteamApi.getCollectionDetails() first!\n"
@@ -43,15 +70,154 @@ def DownloadCollection(collection: WorkshopCollection, directory: str, forceRedo
         )
         return
 
-    hasItemsToDownload = len([
-        item for item
-        in collection.items
-        if item.needsUpdate == True
-    ]) > 0 or forceRedownload
+    logger.LogMessage(
+        f"{logger.StartIndent()}"
+        f"Updating collection: {collection.name}"
+    )
+    collectionDirectory = f"{directory}/{collection.name}"
 
-    if (not hasItemsToDownload):
+    isDownloading = True
+
+    if len(willBeIgnoredIds) > 0:
+        logger.LogMessage(
+            f"{logger.Indent(1)}Ignoring {len(willBeIgnoredIds)} up to date items"
+        )
+
+    if len(willBeDeletedIds) > 0:
+        logger.LogMessage(
+            f"{logger.Indent(1)}Removing {len(willBeDeletedIds)} items"
+        )
+        for index, itemId in enumerate(willBeDeletedIds):
+            itemIndex = localItemIdsList.index(itemId)
+            item = collection.localItems[itemIndex]
+            logger.LogError(
+                f"{logger.Indent(1)}"
+                f"{index}. "
+                f"{item.name}"
+            )
+            itemDirectory = f"{collectionDirectory}/{item.name}"
+            if (filemanager.doesFolderExist(itemDirectory)):
+                filemanager.deleteFolder(itemDirectory)
+
+    if len(willBeUpdatedIds) > 0:
+        logger.LogMessage(
+            f"{logger.Indent(1)}Updating {len(willBeUpdatedIds)} old items"
+        )
+
+        successfulDownloads = 0
+        for index, itemId in enumerate(willBeUpdatedIds):
+            newItemIndex = newItemIdsList.index(itemId)
+            newItem = collection.newItems[newItemIndex]
+            newItemDirectory = f"{collectionDirectory}/{newItem.name}"
+
+            localItemIndex = localItemIdsList.index(itemId)
+            localItem = collection.localItems[localItemIndex]
+            localItemDirectory = f"{collectionDirectory}/{localItem.name}"
+
+            logger.LogMessage(
+                f"{logger.Indent(1)}"
+                f"{index}. "
+                f"{newItem.name}"
+            )
+
+            if (filemanager.doesFolderExist(localItemDirectory)):
+                logger.LogMessage(f"{logger.Indent(2)}Deleting old folder...")
+                filemanager.deleteFolder(localItemDirectory)
+
+            if (filemanager.doesFolderExist(newItemDirectory)):
+                logger.LogMessage(f"{logger.Indent(2)}Deleting old folder...")
+                filemanager.deleteFolder(newItemDirectory)
+
+            try:
+                downloadedData = downloadItem(newItem)
+                logger.LogMessage(f"{logger.Indent(2)}Extracting...")
+                filemanager.saveZipFile(newItemDirectory, downloadedData)
+                successfulDownloads += 1
+            except Exception as exception:
+                logger.LogError(
+                    f"{logger.Indent(1)}{logger.StartIndent()}Exception occured while trying to download item: \n"
+                    f"{logger.Indent(2)}{exception}"
+                )
+            if (stopDownload):
+                logger.LogSuccess(
+                    f"{logger.StartIndent()}Download stopped"
+                )
+                isDownloading = False
+                stopDownload = False
+                return
+
+    if len(willBeAddedIds) > 0:
+        logger.LogMessage(
+            f"{logger.Indent(1)}Downloading {len(willBeAddedIds)} new items"
+        )
+
+        successfulDownloads = 0
+        for index, itemId in enumerate(willBeAddedIds):
+            newItemIndex = newItemIdsList.index(itemId)
+            newItem = collection.newItems[newItemIndex]
+            newItemDirectory = f"{collectionDirectory}/{newItem.name}"
+
+            logger.LogMessage(
+                f"{logger.Indent(1)}"
+                f"{index}. "
+                f"{newItem.name}"
+            )
+
+            try:
+                downloadedData = downloadItem(newItem)
+                logger.LogMessage(f"{logger.Indent(2)}Extracting...")
+                filemanager.saveZipFile(newItemDirectory, downloadedData)
+                successfulDownloads += 1
+            except Exception as exception:
+                logger.LogError(
+                    f"{logger.Indent(1)}{logger.StartIndent()}Exception occured while trying to download item: \n"
+                    f"{logger.Indent(2)}{exception}"
+                )
+            if (stopDownload):
+                logger.LogSuccess(
+                    f"{logger.StartIndent()}Download stopped"
+                )
+                isDownloading = False
+                stopDownload = False
+                return
+
+    collection.saveAsJson(collectionDirectory)
+
+    logger.LogSuccess(
+        f"Downloaded collection: {collection.name}. \
+        Items: {successfulDownloads}/{len(collection.localItems)}"
+    )
+
+
+def DownloadCollection(collection: WorkshopCollection, directory: str, overrideExistingDirectory: bool = False) -> None:
+    '''Downloads all mods in collection.\n
+    WARNING: collections maybe very big, so this command may generate a lot of internet traffic and take a while.'''
+
+    collectionDirectory = f"{directory}/{collection.name}"
+
+    if filemanager.doesFolderExist(collectionDirectory):
+        if (overrideExistingDirectory):
+            filemanager.deleteFolder(collectionDirectory)
+        else:
+            logger.LogError(f"Directory already exists: {collectionDirectory}")
+            return
+
+    global isDownloading
+    global stopDownload
+
+    if (len(collection.newItems) == 0):
         logger.LogError(
             f"{logger.StartIndent()}Collection has no items to download.\n"
+            f"{logger.Indent(1)}Called with collection: {collection}"
+        )
+        return
+
+    hasValidAppId = SteamAPI.Validator.ValidSteamItemId(collection.appid)
+
+    if (not hasValidAppId):
+        logger.LogError(
+            f"{logger.StartIndent()}Can't download collection without knowing its app id.\n"
+            f"{logger.Indent(1)}Call SteamApi.getCollectionDetails() first!\n"
             f"{logger.Indent(1)}Called with collection: {collection}"
         )
         return
@@ -60,40 +226,33 @@ def DownloadCollection(collection: WorkshopCollection, directory: str, forceRedo
         f"{logger.StartIndent()}"
         f"Downloading collection: {collection.name}"
     )
-    collectionDirectory = f"{directory}/{collection.name}"
+
+    collection.saveAsJson(collectionDirectory)
 
     isDownloading = True
 
-    skippedDownloads = 0
-    successfulDownloads = 0
-    for index, item in enumerate(collection.items):
+    logger.LogMessage(
+        f"{logger.Indent(1)}Downloading {len(collection.newItems)} items"
+    )
 
-        download = item.needsUpdate or forceRedownload
-        if (not download):
-            logger.LogWarning(
-                f"{logger.Indent(1)}"
-                f"{index}. "
-                f"{item.name}"
-            )
-            skippedDownloads += 1
-            continue
-        else:
-            logger.LogMessage(
-                f"{logger.Indent(1)}"
-                f"{index}. "
-                f"{item.name}"
-            )
+    successfulDownloads = 0
+    for index, item in enumerate(collection.newItems):
+        logger.LogMessage(
+            f"{logger.Indent(1)}"
+            f"{index}. "
+            f"{item.name}"
+        )
         try:
             downloadedData = downloadItem(item)
             itemDirectory = f"{collectionDirectory}/{item.name}"
             if (filemanager.doesFolderExist(itemDirectory)):
                 filemanager.deleteFolder(itemDirectory)
-            print(f"{logger.Indent(2)}Extracting")
+            print(f"{logger.Indent(2)}Extracting...")
             filemanager.saveZipFile(itemDirectory, downloadedData)
             successfulDownloads += 1
         except Exception as exception:
             logger.LogError(
-                f"{logger.Indent(1)}{logger.StartIndent()}Exception occured while trying to download collection\n"
+                f"{logger.Indent(1)}{logger.StartIndent()}Exception occured while trying to download item: \n"
                 f"{logger.Indent(2)}{exception}"
             )
         if (stopDownload):
@@ -104,11 +263,9 @@ def DownloadCollection(collection: WorkshopCollection, directory: str, forceRedo
             stopDownload = False
             return
 
-    collection.saveAsJson(collectionDirectory)
-
     logger.LogSuccess(
         f"Downloaded collection: {collection.name}. \
-        Items: {successfulDownloads}/{len(collection.items)}"
+        Items: {successfulDownloads}/{len(collection.newItems)}"
     )
 
 
@@ -167,8 +324,10 @@ def getSteamDownloaderCachedUrl(item: WorkshopItem):
 def downloadItem(item: WorkshopItem):
     '''Downloads item.'''
 
+    downloadBarLength = 30
+
     if (not SteamAPI.Validator.ValidSteamItemId(item.id) or
-            not SteamAPI.Validator.ValidSteamItemId(item.appid)
+        not SteamAPI.Validator.ValidSteamItemId(item.appid)
         ):
         raise Exception(
             "Can't download item without knowing its id or its app id."
@@ -177,26 +336,30 @@ def downloadItem(item: WorkshopItem):
     zipFileUrl = getSteamDownloaderUrl(item)
     if (not zipFileUrl):
         logger.LogError(
-            f"{logger.Indent(3)}Error downloading. Please try ot download this item manually."
+            f"{logger.Indent(2)}Error downloading. Please try ot download this item manually."
         )
         return
 
     with io.BytesIO() as memoryFile:
         downloadResponse = requests.get(zipFileUrl, stream=True)
         totalLength = downloadResponse.headers.get('content-length')
-        downloadedBytesSize = 0
         if totalLength is None:
             memoryFile.write(downloadResponse.content)
             logger.LogWarning(
                 f"{logger.Indent(2)}Can't track download progress. Downloading..."
             )
         else:
+            print(
+                f"{logger.Indent(2)}Downloading [{' ' * downloadBarLength}]", end="\r"
+            )
             for chunk in downloadResponse.iter_content(1024):
-                downloadedBytesSize += len(chunk)
                 memoryFile.write(chunk)
-                done = int(30 * downloadedBytesSize / int(totalLength))
+                downloadBarDone = int(
+                    downloadBarLength *
+                    memoryFile.getbuffer().nbytes / int(totalLength)
+                )
                 print(
-                    f"{logger.Indent(2)}Downloading [{'=' * done}{' ' * (30-done)}]", end="\r"
+                    f"{logger.Indent(2)}Downloading [{'=' * downloadBarDone}{' ' * (downloadBarLength-downloadBarDone)}]", end="\r"
                 )
         logger.LogMessage("")
         memoryFile.seek(0)

--- a/classes/workshopCollection.py
+++ b/classes/workshopCollection.py
@@ -4,47 +4,35 @@ import json
 from classes.workshopItemBase import WorkshopItemBase
 from classes.workshopItem import WorkshopItem
 
-from utils import logger
+from utils import logger, filemanager
 from api import SteamAPI
 
 
 class WorkshopCollection(WorkshopItemBase):
-    items: list[WorkshopItem] = []
+    localItems: list[WorkshopItem] = []
+    newItems: list[WorkshopItem] = []
 
-    def __init__(self, id: str, appid: int = -1, name: str = "", items: list[WorkshopItem] = []) -> None:
-        self.items = items
+    def __init__(self, id: str, appid: int = -1, name: str = "", localItems: list[WorkshopItem] = []) -> None:
         if (SteamAPI.Validator.ValidSteamItemId(id)):
             super().__init__(id, appid, name)
-            title, appid, updatedItems = SteamAPI.GetWorkshopCollectionInfo(
+            title, appid, newItems = SteamAPI.GetWorkshopCollectionInfo(
                 self.id
             )
             self.name = title
             self.appid = appid
-            # BAD
-            BADFIXItems = []
-            for item in updatedItems:
-                item.needsUpdate = True
-                BADFIXItems.append(item)
-            self.updateItemRegisters(BADFIXItems)
+            self.newItems = newItems
         else:
-            if (id == "DummyIdForLocalCollection" and len(self.items) > 0):
+            if (len(localItems) > 0):
                 super().__init__(id, appid, name)
-                itemIds = [x.id for x in self.items]
-                updatedItems = SteamAPI.GetItemsUpdatedInfo(itemIds)
-                self.updateItemRegisters(updatedItems)
+                self.localItems = localItems
+                self.newItems = SteamAPI.GetLocalCollectionInfo(
+                    self.localItems
+                )
             else:
                 raise Exception(
-                    f"Workshop collection: incorrect id: {id}"
+                    "Could not create a collection.\n"
+                    f"Params: {id}, {appid}, {name}, {localItems}"
                 )
-
-    def updateItemRegisters(self, updatedItems: WorkshopItem):
-        for index, updatedItem in enumerate(updatedItems):
-            if (len(self.items) > index):
-                if (self.items[index].lastUpdated != updatedItem.lastUpdated):
-                    updatedItem.needsUpdate = True
-                self.items[index] = updatedItem
-            else:
-                self.items.append(updatedItem)
 
     @classmethod
     def fromUrl(cls, url: str):
@@ -53,10 +41,10 @@ class WorkshopCollection(WorkshopItemBase):
 
     @classmethod
     def fromJson(cls, jsonDict: str):
-        id = "DummyIdForLocalCollection"  # jsonDict.get("collectionId")
+        id = None
         appid = jsonDict.get("appId")
         name = jsonDict.get("collectionName")
-        items = jsonDict.get("items")
+        jsonItems = jsonDict.get("items")
 
         if (appid is None):
             logger.LogError(
@@ -64,7 +52,7 @@ class WorkshopCollection(WorkshopItemBase):
             )
             return
 
-        if (items is None):
+        if (jsonItems is None):
             logger.LogError(
                 "You are specifying local collection, but no items were found!"
             )
@@ -73,64 +61,67 @@ class WorkshopCollection(WorkshopItemBase):
         if (name is None):
             name = "NotInCollection"
 
-        wItems: list[WorkshopItem] = []
+        localItems: list[WorkshopItem] = []
         ids: list[str] = []
         names: list[str] = []
-        for item in items:
+        for jsonItem in jsonItems:
             wItem = WorkshopItem(
-                int(item.get("itemId")),
-                item.get("appId"),
-                item.get("itemName"),
-                item.get("lastUpdated")
+                jsonItem.get("itemId"),
+                jsonItem.get("appId"),
+                jsonItem.get("itemName"),
+                jsonItem.get("lastUpdated")
             )
             if (wItem.id is None):
                 logger.LogError(
-                    f"Error parsing item: {item}. Item id is not specified!"
+                    f"Error parsing item: {jsonItem}. Item id is not specified!"
                 )
                 continue
 
             if (wItem.appid and wItem.appid != appid):
                 logger.LogError(
-                    f"Error parsing item: {item}. Item appid does not match collection id!"
+                    f"Error parsing item: {jsonItem}. Item appid does not match collection id!"
                 )
                 continue
 
             if (wItem.id in ids or wItem.name in names):
-                dups = [x for x in items
-                        if (x.id == wItem.id or x.name == wItem.name)
-                        ]
+                dups = [
+                    x for x
+                    in jsonItems
+                    if x.id == wItem.id or x.name == wItem.name
+                ]
                 logger.LogWarning(
                     "Possible duplicates:\n"
                     f"{wItem}"
                 )
                 for idx, dup in enumerate(dups):
                     logger.LogWarning(f"    {idx}. - {dup}")
-            wItems.append(wItem)
 
-        if (len(wItems) == 0):
+            ids.append(wItem.id)
+            names.append(wItem.name)
+            localItems.append(wItem)
+
+        if (len(localItems) == 0):
             logger.LogError(
-                "You are specifying local collection, but no mods were parsed successfully!"
+                "You are specifying local collection, but no items were parsed successfully!"
             )
             return
 
-        return cls(id, appid, name, wItems)
+        return cls(id, appid, name, localItems)
 
     def json(self):
         '''Retuns dict with name, id, and app id.'''
         return {"collectionName": self.name, "collectionId": self.id, "appId": self.appid}
 
     def saveAsJson(self, directory):
-        if (not os.path.exists(directory)):
-            os.makedirs(directory)
+        if (not filemanager.doesFolderExist(directory)):
+            filemanager.createFolder(directory)
 
         with open(f"{directory}/collection.json", "w") as file:
             data = self.json()
-
-            jsonItems = []
-            for item in self.items:
-                jsonItems.append(item.json())
-
-            data["items"] = jsonItems
+            data["items"] = [
+                item.json() for item
+                in self.newItems
+            ]
             file.write(json.dumps(data))
 
     def __str__(self) -> str:

--- a/classes/workshopCollection.py
+++ b/classes/workshopCollection.py
@@ -113,8 +113,8 @@ class WorkshopCollection(WorkshopItemBase):
         return {"collectionName": self.name, "collectionId": self.id, "appId": self.appid}
 
     def saveAsJson(self, directory):
-        if (not filemanager.doesFolderExist(directory)):
-            filemanager.createFolder(directory)
+        if (not filemanager.doesDirectoryExist(directory)):
+            filemanager.createDirectory(directory)
 
         with open(f"{directory}/collection.json", "w") as file:
             data = self.json()

--- a/classes/workshopItem.py
+++ b/classes/workshopItem.py
@@ -2,11 +2,8 @@ from classes import WorkshopItemBase
 
 
 class WorkshopItem(WorkshopItemBase):
-    needsUpdate: bool = False
-
-    def __init__(self, id: int, appid: int = -1, name: str = "", lastUpdated: str = "", needsUpdate: bool = False) -> None:
+    def __init__(self, id: int, appid: int = -1, name: str = "", lastUpdated: str = "") -> None:
         super().__init__(id, appid, name, lastUpdated)
-        self.needsUpdate = needsUpdate
 
     @classmethod
     def fromJson(cls, json):

--- a/classes/workshopItemBase.py
+++ b/classes/workshopItemBase.py
@@ -73,7 +73,7 @@ class WorkshopItemBase:
         self._version = value
 
     def __str__(self) -> str:
-        return f"{{WorkshopItem - name: {self.name} | id: {self.id} | appid: {self.appid} | lastUpdated: {self.lastUpdated}}}"
+        return f"{{WorkshopItemBase - name: {self.name} | id: {self.id} | appid: {self.appid} | lastUpdated: {self.lastUpdated}}}"
 
     def __repr__(self) -> str:
         return self.__str__()

--- a/utils/filemanager.py
+++ b/utils/filemanager.py
@@ -29,6 +29,10 @@ def deleteFolder(path: str) -> None:
     shutil.rmtree(path)
 
 
+def createFolder(path: str) -> None:
+    os.makedirs(path)
+
+
 def saveZipFile(directory: str, zipFileBytes: bytes):
     if (zipFileBytes == None):
         raise Exception(

--- a/utils/filemanager.py
+++ b/utils/filemanager.py
@@ -6,7 +6,7 @@ import zipfile
 from utils import logger
 
 
-def doesFolderExist(path: str) -> bool:
+def doesDirectoryExist(path: str) -> bool:
     return os.path.isdir(path)
 
 
@@ -14,8 +14,8 @@ def doesFileExist(path: str) -> bool:
     return os.path.isfile(path)
 
 
-def deleteFolderContents(path: str) -> None:
-    if (not doesFolderExist(path)):
+def deleteAllDirectoryContents(path: str) -> None:
+    if (not doesDirectoryExist(path)):
         raise Exception(f"Folder does not exist: {path}")
 
     for root, dirs, files in os.walk('/path/to/folder'):
@@ -25,12 +25,26 @@ def deleteFolderContents(path: str) -> None:
             shutil.rmtree(os.path.join(root, d))
 
 
-def deleteFolder(path: str) -> None:
+def deleteDirectory(path: str) -> None:
     shutil.rmtree(path)
 
 
-def createFolder(path: str) -> None:
+def createDirectory(path: str) -> None:
     os.makedirs(path)
+
+
+def listDirsInDirectory(path: str) -> list[str]:
+    return (dir for dir
+            in os.listdir(path)
+            if doesDirectoryExist(os.path.join(path, dir))
+            )
+
+
+def listFilesInDirectory(path: str) -> list[str]:
+    return (file for file
+            in os.listdir(path)
+            if doesFileExist(os.path.join(path, file))
+            )
 
 
 def saveZipFile(directory: str, zipFileBytes: bytes):
@@ -39,7 +53,7 @@ def saveZipFile(directory: str, zipFileBytes: bytes):
             "zipFileBytes is None."
         )
 
-    if (doesFolderExist(directory)):
+    if (doesDirectoryExist(directory)):
         raise Exception(
             f"Folder already exists: {directory}"
         )

--- a/wcd.py
+++ b/wcd.py
@@ -16,12 +16,12 @@ def parseArgs():
     group.add_argument("-curl",
                        "--collectionUrl",
                        type=str,
-                       help="Steam collection url.\nPattern: https://steamcommunity.com/workshop/filedetails/?id=*")
+                       help="Steam collection url. Pattern: https://steamcommunity.com/sharedfiles/filedetails/?id=*")
 
     group.add_argument("-cjson",
                        "--collectionJson",
                        type=str,
-                       help="Generated JSON file from this script.")
+                       help="Generated collection.json file from this script.")
 
     parser.add_argument("-o",
                         "--output",
@@ -63,9 +63,14 @@ def main():
         wCollection = WorkshopCollection.fromJson(jsonDict)
 
     try:
-        SteamDownloaderAPI.DownloadCollection(
-            wCollection, OutputDirectory, ForceRedownload
-        )
+        if (SteamCollectionUrl):
+            SteamDownloaderAPI.DownloadCollection(
+                wCollection, OutputDirectory, ForceRedownload
+            )
+        else:
+            SteamDownloaderAPI.UpdateCollection(
+                wCollection, OutputDirectory
+            )
     except KeyboardInterrupt:
         SteamDownloaderAPI.StopDownload()
 

--- a/wcd.py
+++ b/wcd.py
@@ -33,12 +33,12 @@ def parseArgs():
     parser.add_argument("-f", "--force",
                         required=False,
                         action="store_true",
-                        help="Force redownload everything.")
+                        help="Force redownload everything. (only when updating)")
 
     parser.add_argument("-c", "--cleanUp",
                         required=False,
                         action="store_true",
-                        help="Clean up removed items")
+                        help="Clean up removed items. (only when updating)")
 
     args = parser.parse_args()
 
@@ -69,9 +69,9 @@ def main():
         wCollection = WorkshopCollection.fromJson(jsonDict)
 
     try:
-        if (SteamCollectionUrl):
+        if (SteamCollectionUrl or ForceRedownload):
             SteamDownloaderAPI.DownloadCollection(
-                wCollection, OutputDirectory, ForceRedownload
+                wCollection, OutputDirectory, True
             )
         else:
             SteamDownloaderAPI.UpdateCollection(

--- a/wcd.py
+++ b/wcd.py
@@ -33,17 +33,23 @@ def parseArgs():
     parser.add_argument("-f", "--force",
                         required=False,
                         action="store_true",
-                        help="Force to redownload everything xD.")
+                        help="Force redownload everything.")
+
+    parser.add_argument("-c", "--cleanUp",
+                        required=False,
+                        action="store_true",
+                        help="Clean up removed items")
 
     args = parser.parse_args()
 
     directory = os.path.abspath(args.output)
     force = args.force
+    cleanUp = args.cleanUp
 
     steamUrl = args.collectionUrl
     jsonPath = args.collectionJson
 
-    return directory, force, steamUrl, jsonPath
+    return directory, force, steamUrl, jsonPath, cleanUp
 
 
 def readJsonFile(jsonPath):
@@ -52,7 +58,7 @@ def readJsonFile(jsonPath):
 
 
 def main():
-    OutputDirectory, ForceRedownload, SteamCollectionUrl, JsonFilePath = parseArgs()
+    OutputDirectory, ForceRedownload, SteamCollectionUrl, JsonFilePath, CleanUp = parseArgs()
 
     wCollection = None
     if (SteamCollectionUrl):
@@ -69,7 +75,7 @@ def main():
             )
         else:
             SteamDownloaderAPI.UpdateCollection(
-                wCollection, OutputDirectory
+                wCollection, OutputDirectory, True, CleanUp
             )
     except KeyboardInterrupt:
         SteamDownloaderAPI.StopDownload()

--- a/wcd.py
+++ b/wcd.py
@@ -1,4 +1,4 @@
-# 1.0.1
+# 1.1.1
 
 import argparse
 import os


### PR DESCRIPTION
1. When updating, items that are up to date are skipped and not shown.
2. When updating, old folders are deleted so that no files are left over, even if item changed name (example: 'my-mod-1' changed name to 'my-mod-2'. The script will recognize this and delete the folder 'my-mod-1' and save the new version to 'my-mod-2'.)
3. When updating, -c (--cleanUp) option allows to remove all folders no longer associated with collection. (Example: you removed 'my-mod-1' from collection.json file. The script will recognize this and delete folder 'my-mod-1'.)
4. -f (--force) is now actually redownloading the whole collection.