### PR TITLE
Update 1.1.4

### DIFF
--- a/api/SteamAPI.py
+++ b/api/SteamAPI.py
@@ -15,15 +15,14 @@ class Validator:
     def ValidSteamItemUrl(url: str) -> bool:
         '''Checks if steam item url is valid'''
         regexString = "(?:https?:\/\/)?steamcommunity\.com\/sharedfiles\/filedetails\/(?:\?id=)[0-9]+"
-        if not isinstance(url, str):
+        if (not isinstance(url, str)):
             return False
         return False if re.match(regexString, url) is None else True
 
+    @staticmethod
     def ValidSteamItemId(id: int) -> bool:
         '''Checks if steam item id is valid'''
-        if not isinstance(id, int):
-            return False
-        return True
+        return isinstance(id, int) and id > 0
 
 
 class Converter:
@@ -31,10 +30,10 @@ class Converter:
     def IdFromUrl(url: str) -> int:
         '''Returns id from steam url.'''
         if (not Validator.ValidSteamItemUrl(url)):
-            return
+            return None
         id = int(url.split("?id=")[1])
         if (not Validator.ValidSteamItemId(id)):
-            return
+            return None
         return id
 
     @staticmethod
@@ -157,7 +156,7 @@ def GetWorkshopCollectionInfo(collectionId: str) -> tuple[str, int, list[Worksho
     collectionItemsIdList = [
         int(item["publishedfileid"]) for item
         in collectionDetails["children"]
-        if item["filetype"] == 0
+        if (item["filetype"] == 0)
     ]
 
     UpdatedItemsInfo = GetItemsInfo(

--- a/classes/workshopCollection.py
+++ b/classes/workshopCollection.py
@@ -1,16 +1,14 @@
-import os
-import json
 
-from classes.workshopItemBase import WorkshopItemBase
-from classes.workshopItem import WorkshopItem
+from classes import WorkshopItemBase
+from classes import WorkshopItem
 
-from utils import logger, filemanager
+from utils import logger
 from api import SteamAPI
 
 
 class WorkshopCollection(WorkshopItemBase):
     localItems: list[WorkshopItem] = []
-    newItems: list[WorkshopItem] = []
+    fetchedItems: list[WorkshopItem] = []
 
     def __init__(self, id: str, appid: int = -1, name: str = "", localItems: list[WorkshopItem] = []) -> None:
         if (SteamAPI.Validator.ValidSteamItemId(id)):
@@ -20,12 +18,12 @@ class WorkshopCollection(WorkshopItemBase):
             )
             self.name = title
             self.appid = appid
-            self.newItems = newItems
+            self.fetchedItems = newItems
         else:
             if (len(localItems) > 0):
                 super().__init__(id, appid, name)
                 self.localItems = localItems
-                self.newItems = SteamAPI.GetLocalCollectionInfo(
+                self.fetchedItems = SteamAPI.GetLocalCollectionInfo(
                     self.localItems
                 )
             else:
@@ -48,7 +46,7 @@ class WorkshopCollection(WorkshopItemBase):
 
         if (appid is None):
             logger.LogError(
-                "Please specify appid for your collection!"
+                "You are specifying local collection, but no appid was found!"
             )
             return
 
@@ -61,9 +59,9 @@ class WorkshopCollection(WorkshopItemBase):
         if (name is None):
             name = "NotInCollection"
 
-        localItems: list[WorkshopItem] = []
-        ids: list[str] = []
-        names: list[str] = []
+        parsedItems: list[WorkshopItem] = []
+        parsedItemsIds: list[str] = []
+        parsedItemsNames: list[str] = []
         for jsonItem in jsonItems:
             wItem = WorkshopItem(
                 jsonItem.get("itemId"),
@@ -83,46 +81,57 @@ class WorkshopCollection(WorkshopItemBase):
                 )
                 continue
 
-            if (wItem.id in ids or wItem.name in names):
+            if (wItem.id in parsedItemsIds or wItem.name in parsedItemsNames):
                 dups = [
-                    x for x
+                    item for item
                     in jsonItems
-                    if x.id == wItem.id or x.name == wItem.name
+                    if item.get("id") == wItem.id or item.get("name") == wItem.name
                 ]
                 logger.LogWarning(
-                    "Possible duplicates:\n"
-                    f"{wItem}"
+                    f"Possible duplicates for {wItem}:\n"
                 )
                 for idx, dup in enumerate(dups):
-                    logger.LogWarning(f"    {idx}. - {dup}")
+                    logger.LogWarning(f"{logger.StartIndent()}{idx}. - {dup}")
 
-            ids.append(wItem.id)
-            names.append(wItem.name)
-            localItems.append(wItem)
+            parsedItemsIds.append(wItem.id)
+            parsedItemsNames.append(wItem.name)
+            parsedItems.append(wItem)
 
-        if (len(localItems) == 0):
+        if (len(parsedItems) == 0):
             logger.LogError(
                 "You are specifying local collection, but no items were parsed successfully!"
             )
             return
 
-        return cls(id, appid, name, localItems)
+        return cls(id, appid, name, parsedItems)
+
+    @staticmethod
+    def getItemsByName(items: list[WorkshopItem], name: str) -> list[WorkshopItem]:
+        if (not SteamAPI.Validator.ValidSteamItemId(id)):
+            raise Exception("Item id is not valid")
+
+        result = [item for item in items if item.name == name]
+        return result
+
+    @staticmethod
+    def getItemById(items: list[WorkshopItem], id: int) -> WorkshopItem:
+        if (not SteamAPI.Validator.ValidSteamItemId(id)):
+            raise Exception("Item id is not valid")
+
+        result = [item for item in items if item.id == id]
+        return result[0] if len(result) > 0 else None
+
+    @staticmethod
+    def getItemNames(items: list[WorkshopItem]):
+        return [item.name for item in items]
+
+    @staticmethod
+    def getItemIds(items: list[WorkshopItem]):
+        return [item.id for item in items]
 
     def json(self):
         '''Retuns dict with name, id, and app id.'''
         return {"collectionName": self.name, "collectionId": self.id, "appId": self.appid}
-
-    def saveAsJson(self, directory):
-        if (not filemanager.doesDirectoryExist(directory)):
-            filemanager.createDirectory(directory)
-
-        with open(f"{directory}/collection.json", "w") as file:
-            data = self.json()
-            data["items"] = [
-                item.json() for item
-                in self.newItems
-            ]
-            file.write(json.dumps(data))
 
     def __str__(self) -> str:
         return f"{{WorkshopCollection - name: {self.name} | id: {self.id} | appid: {self.appid} }}"

--- a/classes/workshopItem.py
+++ b/classes/workshopItem.py
@@ -2,7 +2,7 @@ from classes import WorkshopItemBase
 
 
 class WorkshopItem(WorkshopItemBase):
-    def __init__(self, id: int, appid: int = -1, name: str = "", lastUpdated: str = "") -> None:
+    def __init__(self, id: int, appid: int = -1, name: str = "", lastUpdated: int = -1) -> None:
         super().__init__(id, appid, name, lastUpdated)
 
     @classmethod

--- a/classes/workshopItemBase.py
+++ b/classes/workshopItemBase.py
@@ -1,6 +1,8 @@
 import unicodedata
 import re
 
+from utils import AssertParameter
+
 
 def slugify(value, allow_unicode=False):
     """
@@ -26,51 +28,47 @@ class WorkshopItemBase:
     _appid: int = -1
     _lastupdated: str = ""
 
-    def __init__(self, id: int, appid: int = -1, name: str = "", lastUpdated: str = "") -> None:
+    def __init__(self, id: int, appid: int = -1, name: str = "", lastUpdated: int = -1) -> None:
         self.id = id
         self.appid = appid
         self.name = name
         self.lastUpdated = lastUpdated
 
     @property
-    def id(self):
+    def id(self) -> int:
         return self._id
 
     @id.setter
-    def id(self, value):
+    def id(self, value: int) -> None:
+        AssertParameter(value, int, "id.value")
         self._id = value
 
     @property
-    def appid(self):
+    def appid(self) -> int:
         return self._appid
 
     @appid.setter
-    def appid(self, value):
-        self._appid = int(value)
+    def appid(self, value: int) -> None:
+        AssertParameter(value, int, "appid.value")
+        self._appid = value
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @name.setter
-    def name(self, value):
+    def name(self, value: str) -> None:
+        AssertParameter(value, str, "name.value")
         self._name = slugify(value)
 
     @property
-    def lastUpdated(self):
+    def lastUpdated(self) -> int:
         return self._lastupdated
 
     @lastUpdated.setter
-    def lastUpdated(self, value):
+    def lastUpdated(self, value: int) -> None:
+        AssertParameter(value, int, "lastUpdated.value")
         self._lastupdated = value
-
-    @property
-    def version(self):
-        return self._version
-
-    @version.setter
-    def version(self, value):
-        self._version = value
 
     def __str__(self) -> str:
         return f"{{WorkshopItemBase - name: {self.name} | id: {self.id} | appid: {self.appid} | lastUpdated: {self.lastUpdated}}}"

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,6 @@
+def AssertParameter(param, paramTypes: tuple, paramName):
+    if (not isinstance(param, paramTypes)):
+        raise TypeError(
+            f"{paramName} must be of type {paramTypes}\n"
+            f"{paramName}: {param}, type: {type(param)}"
+        )

--- a/utils/filemanager.py
+++ b/utils/filemanager.py
@@ -2,8 +2,10 @@ import os
 import shutil
 import io
 import zipfile
+import json
 
-from utils import logger
+from classes import WorkshopCollection
+from classes import WorkshopItem
 
 
 def doesDirectoryExist(path: str) -> bool:
@@ -18,7 +20,7 @@ def deleteAllDirectoryContents(path: str) -> None:
     if (not doesDirectoryExist(path)):
         raise Exception(f"Folder does not exist: {path}")
 
-    for root, dirs, files in os.walk('/path/to/folder'):
+    for root, dirs, files in os.walk(path):
         for f in files:
             os.unlink(os.path.join(root, f))
         for d in dirs:
@@ -60,3 +62,16 @@ def saveZipFile(directory: str, zipFileBytes: bytes):
 
     zipFile = zipfile.ZipFile(io.BytesIO(zipFileBytes))
     zipFile.extractall(directory)
+
+
+def saveCollectionAsJson(collection: WorkshopCollection, items: list[WorkshopItem], directory: str):
+    if (not doesDirectoryExist(directory)):
+        createDirectory(directory)
+
+    with open(f"{directory}/collection.json", "w") as file:
+        data = collection.json()
+        data["items"] = [
+            item.json() for item
+            in items
+        ]
+        file.write(json.dumps(data))

--- a/utils/filemanager.py
+++ b/utils/filemanager.py
@@ -6,6 +6,7 @@ import json
 
 from classes import WorkshopCollection
 from classes import WorkshopItem
+from utils import AssertParameter
 
 
 def doesDirectoryExist(path: str) -> bool:
@@ -16,59 +17,82 @@ def doesFileExist(path: str) -> bool:
     return os.path.isfile(path)
 
 
-def deleteAllDirectoryContents(path: str) -> None:
-    if (not doesDirectoryExist(path)):
-        raise Exception(f"Folder does not exist: {path}")
+# def deleteAllDirectoryContents(path: str) -> None:
+#     if (not doesDirectoryExist(path)):
+#         raise Exception(f"Folder does not exist: {path}")
 
-    for root, dirs, files in os.walk(path):
-        for f in files:
-            os.unlink(os.path.join(root, f))
-        for d in dirs:
-            shutil.rmtree(os.path.join(root, d))
-
-
-def deleteDirectory(path: str) -> None:
-    shutil.rmtree(path)
+#     for root, dirs, files in os.walk(path):
+#         for f in files:
+#             os.unlink(os.path.join(root, f))
+#         for d in dirs:
+#             shutil.rmtree(os.path.join(root, d))
 
 
-def createDirectory(path: str) -> None:
-    os.makedirs(path)
+def deleteDirectory(directory: str) -> None:
+    AssertParameter(directory, str, "directory")
+
+    if (not doesDirectoryExist(directory)):
+        raise Exception(f"{directory} does not exist!")
+
+    shutil.rmtree(directory)
 
 
-def listDirsInDirectory(path: str) -> list[str]:
-    return (dir for dir
-            in os.listdir(path)
-            if doesDirectoryExist(os.path.join(path, dir))
-            )
+def createDirectory(directory: str) -> None:
+    AssertParameter(directory, str, "directory")
+    os.makedirs(directory)
 
 
-def listFilesInDirectory(path: str) -> list[str]:
-    return (file for file
-            in os.listdir(path)
-            if doesFileExist(os.path.join(path, file))
-            )
+def listDirsInDirectory(directory: str) -> list[str]:
+    '''Lists folders in directory'''
+    AssertParameter(directory, str, "directory")
+
+    if (not doesDirectoryExist(directory)):
+        raise Exception(f"{directory} does not exist!")
+
+    return [
+        dir for dir
+        in os.listdir(directory)
+        if doesDirectoryExist(os.path.join(directory, dir))
+    ]
+
+
+def listFilesInDirectory(directory: str) -> list[str]:
+    '''Lists files in directory'''
+    AssertParameter(directory, str, "directory")
+    return [
+        file for file
+        in os.listdir(directory)
+        if doesFileExist(os.path.join(directory, file))
+    ]
 
 
 def saveZipFile(directory: str, zipFileBytes: bytes):
-    if (zipFileBytes == None):
-        raise Exception(
-            "zipFileBytes is None."
-        )
+    '''Extracts bytes of a zipfile to a folder'''
+    AssertParameter(directory, str, "directory")
+    AssertParameter(zipFileBytes, bytes, "zipFileBytes")
 
     if (doesDirectoryExist(directory)):
-        raise Exception(
-            f"Folder already exists: {directory}"
-        )
+        raise Exception(f"Directory already exists: {directory}")
 
     zipFile = zipfile.ZipFile(io.BytesIO(zipFileBytes))
     zipFile.extractall(directory)
 
 
-def saveCollectionAsJson(collection: WorkshopCollection, items: list[WorkshopItem], directory: str):
-    if (not doesDirectoryExist(directory)):
-        createDirectory(directory)
+def saveCollectionAsJson(path: str, collection: WorkshopCollection, items: list[WorkshopItem], overrideFile: False):
+    '''Saves collection to .json file. path MUST include filename and end with .json'''
+    AssertParameter(path, str, "path")
+    AssertParameter(collection, WorkshopCollection, "collection")
+    AssertParameter(items, list, "items")
+    for item in items:
+        AssertParameter(item, WorkshopItem, f"items.{item.name}")
 
-    with open(f"{directory}/collection.json", "w") as file:
+    if (path.split(".")[-1] != "json"):
+        raise ValueError(f"path ({path}) must end with .json")
+
+    if (doesFileExist(path) and not overrideFile):
+        raise FileExistsError(f"{path} already exists!")
+
+    with open(f"{path}", "w") as file:
         data = collection.json()
         data["items"] = [
             item.json() for item

--- a/utils/filemanager.py
+++ b/utils/filemanager.py
@@ -73,7 +73,7 @@ def saveZipFile(directory: str, zipFileBytes: bytes):
 
     if (doesDirectoryExist(directory)):
         raise Exception(f"Directory already exists: {directory}")
-
+    
     zipFile = zipfile.ZipFile(io.BytesIO(zipFileBytes))
     zipFile.extractall(directory)
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -4,6 +4,14 @@ import os
 os.system("")
 
 
+def ProgressBar(length: int, percentage: int):
+    filledBars = int(
+        length *
+        percentage / 100
+    )
+    return f"[{'=' * filledBars}{' ' * (length - filledBars)}]"
+
+
 def StartIndent():
     return " - "
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,10 +1,22 @@
 from termcolor import colored
 import os
 
+from utils import AssertParameter
+
 os.system("")
 
 
-def ProgressBar(length: int, percentage: int):
+def ProgressBar(length: int, percentage: float) -> str:
+    '''Creates a progress bar where max amount of filled bars = length.'''
+    AssertParameter(length, int, "length")
+    AssertParameter(percentage, (int, float), "percentage")
+
+    if (length < 1):
+        raise ValueError("Length of progress bar must be greater than 0!")
+
+    if (percentage < 0 or percentage > 100):
+        raise ValueError("Fill percentage must be in range [0, 100]")
+
     filledBars = int(
         length *
         percentage / 100
@@ -12,25 +24,68 @@ def ProgressBar(length: int, percentage: int):
     return f"[{'=' * filledBars}{' ' * (length - filledBars)}]"
 
 
-def StartIndent():
+def YesOrNoQuery(question: str, default: bool = True, yesTooltip: str = "", noTooltip: str = "") -> bool:
+    '''Creates a yes/no prompt with question, tooltips and default value. Returns True/False for yes/no'''
+    AssertParameter(question, str, "question")
+    AssertParameter(default, bool, "default")
+    AssertParameter(yesTooltip, str, "yesTooltip")
+    AssertParameter(noTooltip, str, "noTooltip")
+
+    valid = {"yes": True, "y": True, "no": False, "n": False}
+
+    yesTooltipText = f": {yesTooltip} " if yesTooltip != "" else " "
+    noTooltipText = f": {noTooltip}" if noTooltip != "" else ""
+
+    if (default is None):
+        prompt = f"\n[y{yesTooltipText}/ n{noTooltipText}]"
+    elif (default):
+        prompt = f"\n[Y{yesTooltipText}/ n{noTooltipText}]"
+    elif (not default):
+        prompt = f"\n[y{yesTooltipText}/ N{noTooltipText}]"
+    else:
+        raise ValueError(f"Invalid default answer: '{default}'")
+
+    while True:
+        LogWarning(question + prompt)
+        choice = input().lower()
+        if (default is not None and choice == ""):
+            return default
+        elif (choice in valid):
+            return valid[choice]
+        else:
+            yesValid = "/".join([item for item in valid if valid[item]])
+            noValid = "/".join([item for item in valid if not valid[item]])
+            LogError(
+                f"Please respond with {yesValid} for yes, {noValid} for no.\n"
+            )
+
+
+def StartIndent() -> str:
+    '''Retuns start indent'''
     return " - "
 
 
-def Indent(indentLevel):
-    return "   " * indentLevel
+def Indent(level: int) -> str:
+    '''Retuns indent multiplied by level'''
+    AssertParameter(level, int, "level")
+    return "   " * level
 
 
-def LogSuccess(message: str):
+def LogSuccess(message: str) -> None:
+    '''Prints green-colored success message'''
     print(colored(message, "green"))
 
 
-def LogMessage(message: str):
+def LogMessage(message: str) -> None:
+    '''Prints message'''
     print(message)
 
 
-def LogWarning(warning: str):
+def LogWarning(warning: str) -> None:
+    '''Prints yellow-colored warning message'''
     print(colored(warning, "yellow"))
 
 
-def LogError(error: str):
+def LogError(error: str) -> None:
+    '''Prints red-colored error message'''
     print(colored(error, "red"))

--- a/wcd.py
+++ b/wcd.py
@@ -1,4 +1,4 @@
-# 1.1.1
+# 1.1.2
 
 import argparse
 import os

--- a/wcd.py
+++ b/wcd.py
@@ -1,4 +1,4 @@
-# 1.1.3
+# 1.1.4
 
 import argparse
 import os

--- a/wcd.py
+++ b/wcd.py
@@ -1,4 +1,4 @@
-# 1.1.2
+# 1.1.3
 
 import argparse
 import os


### PR DESCRIPTION
Usability:
1. Now accounts for failed downloads.
2. Now can resume from point where script was stopped (use --cjson).
3. Now creates backups for collection.json in case something goes horribly wrong.

Code:
1. WorkshopCollection.newItems renamed to WorkshopCollection.fetchedItems
2. Fixed SteamDownloaderAPI global variables not resetting.
3. Error checking in some functions.